### PR TITLE
Feature/keywords from controlled vocabulary

### DIFF
--- a/fgsMetsMods/OAIMetadataFormat_FgsMetsMods.inc.php
+++ b/fgsMetsMods/OAIMetadataFormat_FgsMetsMods.inc.php
@@ -68,6 +68,34 @@ class OAIMetadataFormat_FgsMetsMods extends OAIMetadataFormat {
             }
         }
 
+        $linkedKeywords = [];
+        $simpleKeywords = [];
+        foreach ($keywords as $locale => $kws) {
+            $lang = AppLocale::get3LetterIsoFromLocale($locale);
+            foreach ($kws as $kw) {
+                if (str_contains($kw, 'https://id.kb.se/term')) {
+                    $kwFragments = explode('/', $kw);
+                    $label = end($kwFragments);
+                    array_pop($kwFragments);
+                    $authority = end($kwFragments);
+                    array_push($kwFragments, rawurlencode($label));
+                    $linkedKeywords[] =
+                        [
+                            'lang' => $lang,
+                            'label' => $label,
+                            'uri' => implode('/', $kwFragments),
+                            'authority' => $authority
+                        ];
+                } else {
+                    $simpleKeywords[] =
+                        [
+                            'lang' => $lang,
+                            'keyword' => $kw
+                        ];
+                }
+            }
+        }
+
         $templateMgr = TemplateManager::getManager();
         $templateMgr->assign(array(
             'journal' => $journal,
@@ -75,7 +103,8 @@ class OAIMetadataFormat_FgsMetsMods extends OAIMetadataFormat {
             'articleUrl' => $articleUrl,
             'issue' => $record->getData('issue'),
             'section' => $record->getData('section'),
-            'keywords' => $keywords[$article->getLocale()],
+            'keywords' => $simpleKeywords,
+            'linkedKeywords' => $linkedKeywords,
             'galleyProps' => $galleyProps,
             'fileGroups' => $fileGroups,
             'pluginName' => $plugin->getDisplayName(),

--- a/fgsMetsMods/OAIMetadataFormat_FgsMetsMods.inc.php
+++ b/fgsMetsMods/OAIMetadataFormat_FgsMetsMods.inc.php
@@ -74,16 +74,20 @@ class OAIMetadataFormat_FgsMetsMods extends OAIMetadataFormat {
             $lang = AppLocale::get3LetterIsoFromLocale($locale);
             foreach ($kws as $kw) {
                 if (str_contains($kw, 'https://id.kb.se/term')) {
-                    $kwFragments = explode('/', $kw);
-                    $label = end($kwFragments);
-                    array_pop($kwFragments);
-                    $authority = end($kwFragments);
-                    array_push($kwFragments, rawurlencode($label));
+                    $prefLabelAndUri = explode('|', $kw);
+                    $prefLabel = $prefLabelAndUri[0];
+                    $uriDecoded = end($prefLabelAndUri);
+
+                    $uriFragments = explode('/', $uriDecoded);
+                    $label = end($uriFragments);
+                    array_pop($uriFragments);
+                    $authority = end($uriFragments);
+                    array_push($uriFragments, rawurlencode($label));
                     $linkedKeywords[] =
                         [
                             'lang' => $lang,
-                            'label' => $label,
-                            'uri' => implode('/', $kwFragments),
+                            'label' => $prefLabel,
+                            'uri' => implode('/', $uriFragments),
                             'authority' => $authority
                         ];
                 } else {

--- a/fgsMetsMods/OAIMetadataFormat_FgsMetsMods.inc.php
+++ b/fgsMetsMods/OAIMetadataFormat_FgsMetsMods.inc.php
@@ -29,7 +29,7 @@ class OAIMetadataFormat_FgsMetsMods extends OAIMetadataFormat {
         $galleys = $article->getGalleys();
         $submissionFileService = Services::get('submissionFile');
         $articleUrl = $request->getDispatcher()->url($request, ROUTE_PAGE, null, 'article', 'view', $article->getId());
-
+        
         $temporaryFileManager = new PrivateFileManager();
         $basePath = $temporaryFileManager->getBasePath();
 
@@ -68,19 +68,6 @@ class OAIMetadataFormat_FgsMetsMods extends OAIMetadataFormat {
             }
         }
 
-        // Keyword URI's are decoded (%C3%A4 -> 'ä' etc) when saved in OJS.
-        // This code turns them back to valid URIs.
-        $kwUris = [];
-        foreach ($keywords[$article->getLocale()] as $kw) {
-            if (str_contains($kw, 'https://id.kb.se/term')) {
-                $kwFragments = explode('/', $kw);
-                $label = end($kwFragments);
-                array_pop($kwFragments);
-                array_push($kwFragments, rawurlencode($label));
-                $kwUris[] = implode('/', $kwFragments);
-            }
-        }
-
         $templateMgr = TemplateManager::getManager();
         $templateMgr->assign(array(
             'journal' => $journal,
@@ -88,7 +75,7 @@ class OAIMetadataFormat_FgsMetsMods extends OAIMetadataFormat {
             'articleUrl' => $articleUrl,
             'issue' => $record->getData('issue'),
             'section' => $record->getData('section'),
-            'keywords' => $kwUris,
+            'keywords' => $keywords[$article->getLocale()],
             'galleyProps' => $galleyProps,
             'fileGroups' => $fileGroups,
             'pluginName' => $plugin->getDisplayName(),

--- a/fgsMetsMods/templates/record.tpl
+++ b/fgsMetsMods/templates/record.tpl
@@ -128,10 +128,23 @@
 						{/if}
 					</mods:relatedItem>
 					{foreach $keywords as $keyword}
-					<mods:subject lang="{$articleLanguage}">
-						<mods:topic>{$keyword|escape}</mods:topic>
+					<mods:subject lang="{$keyword.lang}">
+						<mods:topic>{$keyword.keyword|escape}</mods:topic>
 					</mods:subject>
 					{/foreach}
+					{* Remove when Mimer accepts the valueUri attribute *}
+					{foreach $linkedKeywords as $keyword}
+					<mods:subject lang="{$keyword.lang}" authority="{$keyword.authority}">
+						<mods:topic>{$keyword.label|escape}</mods:topic>
+					</mods:subject>
+					{/foreach}
+					{* Activate when Mimer accepts the valueUri attribute!
+					{foreach $linkedKeywords as $keyword}
+						<mods:subject lang="{$keyword.lang}">
+							<mods:topic valueUri="{$keyword.uri}">{$keyword.label}</mods:topic>
+						</mods:subject>
+					{/foreach}
+					*}
 					{if $abstract}
 					<mods:abstract lang="{$articleLanguage|escape}">{$abstract|escape}</mods:abstract>
 					{/if}


### PR DESCRIPTION
Deliver linked keywords like this (following FGS-PUBL):
```
<mods:subject lang="swe" authority="sao" >
<mods:topic>Italienska som främmandespråk</mods:topic>
</mods:subject>
```
Also added support for delivering them like this (when mimer accepts the valueUri attribute):
```
<mods:subject lang="swe">
<mods:topic valueUri="https://id.kb.se/term/sao/Italienska%20som%20fr%C3%A4mmandespr%C3%A5k">Italienska som främmandespråk</mods:topic>
</mods:subject>
```
Anonymous keywords are delivered without the authority attribute:
```
<mods:subject lang="eng" >
<mods:topic>Fish</mods:topic>
</mods:subject> 
```